### PR TITLE
Clipboard support/fixes on Windows

### DIFF
--- a/luigi2 (beta).h
+++ b/luigi2 (beta).h
@@ -5796,12 +5796,12 @@ void *_UIHeapReAlloc(void *pointer, size_t size) {
 	}
 }
 
-void _UIClipboardWriteText(UIWindow *window, char *string) {
-	if (OpenClipboard(window->window)) {
+void _UIClipboardWriteText(UIWindow *window, char *text) {
+	if (OpenClipboard(window->hwnd)) {
 		EmptyClipboard();
-		HGLOBAL memory = GlobalAlloc(GMEM_MOVEABLE | GMEM_ZEROINIT, _UIStringLength(string) + 1);
+		HGLOBAL memory = GlobalAlloc(GMEM_MOVEABLE | GMEM_ZEROINIT, _UIStringLength(text) + 1);
 		char *copy = (char *) GlobalLock(memory);
-		for (uintptr_t i = 0; string[i]; i++) copy[i] = string[i];
+		for (uintptr_t i = 0; text[i]; i++) copy[i] = text[i];
 		GlobalUnlock(copy);
 		SetClipboardData(CF_TEXT, memory);
 		CloseClipboard();
@@ -5809,7 +5809,7 @@ void _UIClipboardWriteText(UIWindow *window, char *string) {
 }
 
 char *_UIClipboardReadTextStart(UIWindow *window, size_t *bytes) {
-	if (!OpenClipboard(window->window)) {
+	if (!OpenClipboard(window->hwnd)) {
 		return NULL;
 	}
 	
@@ -5847,7 +5847,6 @@ char *_UIClipboardReadTextStart(UIWindow *window, size_t *bytes) {
 }
 
 void _UIClipboardReadTextEnd(UIWindow *window, char *text) {
-	(void) window;
 	UI_FREE(text);
 }
 


### PR DESCRIPTION
This change has two components:

### luigi2 (beta)

- Fixed clipboard support on the Windows platform.

There were errors compiling on Windows due to use of a variable that that doesn't exist (window->window should have been window->hwnd). Some other minor code changes included for consistency with procedure definition and other platforms.

_NOTE: I updated the UIClipboard procedures to use the existing 'hwnd' within the UIWindow struct. On the Linux and Essence code paths the equivalent variable is called 'window'. You could update the variable name from 'hwnd' to 'window' throughout the UI_WINDOWS code path to match the other platforms, however as this is a bigger change I took the simpler approach here. I would be happy to rename the variable throughout and test that it still works if you would prefer._

### luigi

- Back-ported the fixed clipboard support from this update to luigi2 into luigi.

I'm not sure if you plan on maintaining luigi and luigi2 as separate files going forward, but this would be useful for anyone using the luigi header while luigi2 is in beta.