### PR TITLE
Updated UITable scrollbar behaviour

### DIFF
--- a/luigi2 (beta).h
+++ b/luigi2 (beta).h
@@ -2996,8 +2996,8 @@ int _UITableMessage(UIElement *element, UIMessage message, int di, void *dp) {
 	if (message == UI_MSG_PAINT) {
 		UIPainter *painter = (UIPainter *) dp;
 		UIRectangle bounds = element->bounds;
-		bounds.r -= UI_SIZE_SCROLL_BAR * element->window->scale;
 		UIDrawControl(painter, bounds, UI_DRAW_CONTROL_TABLE_BACKGROUND | UI_DRAW_CONTROL_STATE_FROM_ELEMENT(element), NULL, 0, 0, element->window->scale);
+		bounds.r -= UI_SIZE_SCROLL_BAR * element->window->scale;
 		char buffer[256];
 		UIRectangle row = bounds;
 		int rowHeight = UI_SIZE_TABLE_ROW * element->window->scale;
@@ -3072,6 +3072,7 @@ int _UITableMessage(UIElement *element, UIMessage message, int di, void *dp) {
 	} else if (message == UI_MSG_LAYOUT) {
 		UIRectangle scrollBarBounds = element->bounds;
 		scrollBarBounds.l = scrollBarBounds.r - UI_SIZE_SCROLL_BAR * element->window->scale;
+		scrollBarBounds.t += UI_SIZE_TABLE_HEADER * element->window->scale;
 		table->vScroll->maximum = table->itemCount * UI_SIZE_TABLE_ROW * element->window->scale;
 		table->vScroll->page = UI_RECT_HEIGHT(element->bounds) - UI_SIZE_TABLE_HEADER * table->e.window->scale;
 		UIElementMove(&table->vScroll->e, scrollBarBounds, true);


### PR DESCRIPTION
Update so that within a UITable the vertical scrollbar no longer extends into the table header area.

- changes the scrollbar bounds.t so it fits within the table draw area
- moves the table bounds.r update to after UIDrawControl is called for the table header background (UI_DRAW_CONTROL_TABLE_BACKGROUND), so this call paints across the full width